### PR TITLE
Support Https & http2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 .idea
 postgres-data/
+letsencrypt/
+*.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,19 @@ services:
 
   nginx:
     build: ./nginx
+    cap_add:
+      - NET_ADMIN
+    # Set this if you want to use HTTPS with lets encrypt. If so, simply put the domain name at which Flaggr will be accessible (example mydomain.org)
+    #environment:
+    #  - DOMAIN=res260.xyz
+
     depends_on:
       - backend
       - frontend-user
       - frontend-admin
+
+    volumes:
+      - ./letsencrypt:/etc/letsencrypt
     ports:
       - "80:80"
       - "443:443"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,11 +1,12 @@
 FROM nginx:stable-alpine
-RUN mkdir -p /var/log/nginx
+RUN apk add certbot gettext
 RUN mkdir -p /var/www/html
 COPY --from=frontend-user /app/dist /var/www/html
 COPY --from=frontend-admin /app/dist /var/www/html/admin
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY default.conf /etc/nginx/conf.d/default.conf
-RUN chown nginx:nginx /var/www/html
+COPY nginx.conf /etc/nginx/nginx-template.conf
+COPY nginx-http.conf /etc/nginx/nginx-http.conf
+COPY run.sh /
+RUN chmod +x /run.sh
 EXPOSE 80
 EXPOSE 443
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/bin/sh", "/run.sh"]

--- a/nginx/nginx-http.conf
+++ b/nginx/nginx-http.conf
@@ -1,4 +1,29 @@
-server {
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        off;
+
+    keepalive_timeout  60;
+
+    gzip  on;
+
+    upstream docker-backend {
+        server backend:8080;
+    }
+
+    server {
 
   location / {
       root /var/www/html;
@@ -13,4 +38,6 @@ server {
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $server_name;
   }
+}
+
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,61 @@ http {
         server backend:8080;
     }
 
-    include /etc/nginx/conf.d/*.conf;
+    server {
+      listen 80;
+      listen [::]:80;
+      location / {
+        return 301 https://$host$request_uri;
+      }
+    }
+
+    server {
+
+      listen 443 ssl http2;
+      listen [::]:443 ssl http2;
+
+      server_name ${DOMAIN};
+
+      ssl_certificate      /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+      ssl_certificate_key  /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+      # Improve HTTPS performance with session resumption
+      #ssl_session_cache shared:SSL:10m;
+      ssl_session_timeout 10m;
+
+      # Enable server-side protection against BEAST attacks
+      ssl_protocols TLSv1.2;
+      ssl_prefer_server_ciphers on;
+      ssl_ciphers "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384";
+
+      # Aditional Security Headers
+      # ref: https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+      # ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+      add_header X-Frame-Options DENY always;
+
+      # ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+      add_header X-Content-Type-Options nosniff always;
+
+      # ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+      add_header X-Xss-Protection "1; mode=block" always;
+
+
+      location / {
+        root /var/www/html;
+        try_files $uri $uri/ /index.html;
+      }
+
+      location /api {
+         proxy_pass         http://docker-backend;
+         proxy_redirect     off;
+         proxy_set_header   Host $host;
+         proxy_set_header   X-Real-IP $remote_addr;
+         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header   X-Forwarded-Host $server_name;
+      }
+   }
+
 
 }

--- a/nginx/run.sh
+++ b/nginx/run.sh
@@ -1,0 +1,23 @@
+if [ ! -z "${DOMAIN}" ]; then
+
+  echo 'USING HTTPS WITH DOMAIN ${DOMAIN}'
+
+  if [ ! -f /etc/letsencrypt/$DOMAIN/fullchain.pem ]; then
+    certbot certonly -n --agree-tos -m=egg997@gmail.com -d $DOMAIN --standalone --test-cert
+  else
+    certbot renew
+  fi
+
+  echo 'GENERATING NGINX CONF FILE'
+  envsubst '${DOMAIN}' < /etc/nginx/nginx-template.conf > /etc/nginx/nginx.conf
+  echo 'STARTING NGINX'
+
+  nginx -g "daemon off;"
+
+else
+
+  echo 'NOT USING HTTPS BECAUSE $DOMAIN IS NOT SET, FALLBACK TO HTTP'
+
+  nginx -g "daemon off;" -c /etc/nginx/nginx-http.conf
+
+fi


### PR DESCRIPTION
Uses an environment variable. If unset, uses HTTP as usual. If set, uses certbot to get a cert and uses it along HTTP/2.

Depends on #27.

Fixes #13. Fixes #28.